### PR TITLE
compare rm_pt from other sdp and not copy if mismatch

### DIFF
--- a/libsofia-sip-ua/sdp/sdp.c
+++ b/libsofia-sip-ua/sdp/sdp.c
@@ -1890,6 +1890,9 @@ sdp_rtpmap_t *sdp_rtpmap_find_matching(sdp_rtpmap_t const *list,
     if (!su_casematch(rm->rm_encoding, list->rm_encoding))
       continue;
 
+    if (rm->rm_pt != list->rm_pt )
+      continue;
+
     lparam = rm->rm_params; rparam = list->rm_params;
 
     if (lparam == rparam)


### PR DESCRIPTION
When two user agents send SDP with different H264 profiles to each other, the answering agent SDP is affected by its H264 rtpmap code. The code gets copied from the offering (INVITE) agent resulting in SDP attribute mismatch video code.